### PR TITLE
query capability added for messages so we don't have to pull all messages every sync

### DIFF
--- a/tap_gmail/streams.py
+++ b/tap_gmail/streams.py
@@ -31,7 +31,8 @@ class MessageListStream(GmailStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params.update({"includeSpamTrash": self.config["messages.include_spam_trash"]})
+        params["includeSpamTrash"]=self.config["messages.include_spam_trash"]
+        params["q"]=self.config.get("messages.q")
         return params
 
 

--- a/tap_gmail/tap.py
+++ b/tap_gmail/tap.py
@@ -30,6 +30,11 @@ class TapGmail(Tap):
             th.StringType,
             description="Your google refresh token",
         ),
+        th.Property(
+            "messages.q",
+            th.StringType,
+            description="Only return messages matching the specified query. Supports the same query format as the Gmail search box. For example, \"from:someuser@example.com rfc822msgid:<somemsgid@example.com> is:unread\". Parameter cannot be used when accessing the api using the gmail.metadata scope. https://developers.google.com/gmail/api/reference/rest/v1/users.messages/list#query-parameters",
+        ),
         th.Property("user_id", th.StringType, description="Your Gmail User ID"),
         th.Property(
             "messages.include_spam_trash",


### PR DESCRIPTION
Closes https://github.com/kgpayne/tap-gmail/issues/2

Doesn't solve incremental issue but for me this solves the majority of my problems with this tap!